### PR TITLE
haxelib.json: change the URL to the GitHub repo

### DIFF
--- a/mphx/haxelib.json
+++ b/mphx/haxelib.json
@@ -6,7 +6,7 @@
 	"contributors": ["5Mixer"],
 	"releasenote": "First release - Able to run full multiplayer games.",
 	"version": "0.1.0",
-	"url": "https://twitter.com/5mixer",
+	"url": "https://github.com/5Mixer/mphx",
 	"dependencies":
 	{
 


### PR DESCRIPTION
This link appears as "Project Website" on haxelib, so I feel like this makes more sense than linking to Twitter. Linking to the GitHub repo seems to be the general convention.
