### PR TITLE
Allow client/server communication without payload

### DIFF
--- a/example/luxe/basic/client/src/Main.hx
+++ b/example/luxe/basic/client/src/Main.hx
@@ -23,7 +23,7 @@ class Main extends luxe.Game {
         socket = new mphx.client.Client('127.0.0.1', 8001);
 		socket.connect();
 
-        socket.send('join', null);
+        socket.send('join');
 
         socket.events.on('accepted', function (data :{ playerId :String }) {
             myPlayerId = data.playerId;

--- a/mphx/client/IClient.hx
+++ b/mphx/client/IClient.hx
@@ -2,7 +2,7 @@ package mphx.client;
 
 interface IClient
 {
-	public function send(event:String, data:Dynamic):Void;
+	public function send(event:String, ?data:Dynamic):Void;
 	public function close ():Void;
 	public function connect ():Void;
 	public function update(timeout:Float=0):Void;

--- a/mphx/client/TcpClient.hx
+++ b/mphx/client/TcpClient.hx
@@ -179,7 +179,7 @@ class TcpClient implements IClient
 		client = null;
 	}
 
-	public function send (event:String,data:Dynamic){
+	public function send(event:String, ?data:Dynamic){
 		var object = {
 			t: event,
 			data:data

--- a/mphx/client/WebsocketClient.hx
+++ b/mphx/client/WebsocketClient.hx
@@ -50,7 +50,7 @@ class WebsocketClient implements IClient
 		}
 	}
 
-	public function send(event:String, data:Dynamic)
+	public function send(event:String, ?data:Dynamic)
 	{
 		var object = {
 			t: event,

--- a/mphx/server/Room.hx
+++ b/mphx/server/Room.hx
@@ -26,12 +26,12 @@ class Room
 		connections.push(client);
 	}
 
-	public function broadcast(event:String,data:Dynamic):Bool
+	public function broadcast(event:String,?data:Dynamic):Bool
 	{
 		var success = true;
 		for (client in connections)
 		{
-			if (client.send(event,data))
+			if (!client.send(event,data))
 			{
 				success = false;
 			}

--- a/mphx/tcp/Connection.hx
+++ b/mphx/tcp/Connection.hx
@@ -47,10 +47,10 @@ class Connection implements mphx.tcp.IConnection
 		}
 	}
 
-	public function isConnected():Bool { return this.cnx != null && this.cnx.isOpen(); }
+	public function isConnected():Bool { return cnx != null && cnx.isOpen(); }
 
 
-	public function send (event:String,data:Dynamic){
+	public function send(event:String,?data:Dynamic):Bool {
 		var object = {
 			t: event,
 			data:data

--- a/mphx/tcp/IConnection.hx
+++ b/mphx/tcp/IConnection.hx
@@ -4,7 +4,7 @@ import haxe.io.Input;
 
 interface IConnection
 {
-	public function send (event:String,data:Dynamic):Bool;
+	public function send (event:String,?data:Dynamic):Bool;
 	public function onConnect(cnx:NetSock):Void;
 	public function dataReceived(input:Input):Void;
 	public function loseConnection(?reason:String):Void;

--- a/mphx/tcp/WebsocketProtocol.hx
+++ b/mphx/tcp/WebsocketProtocol.hx
@@ -39,7 +39,7 @@ class WebsocketProtocol extends mphx.tcp.Connection implements mphx.tcp.IConnect
 		_headers=new Array<String>();
 	}
 
-	override public function send (event:String,data:Dynamic)
+	override public function send(event:String,?data:Dynamic) :Bool
 	{
 		var object = {
 			t: event,


### PR DESCRIPTION
Removes the requirement of a data payload for communication, e.g. `socket.send('join', null);` can now be written as `socket.send('join');`.

(Also fixes error in `Room.hx`)
