### PR TITLE
[fix] flash server

### DIFF
--- a/mphx/client/impl/TcpFlashClient.hx
+++ b/mphx/client/impl/TcpFlashClient.hx
@@ -1,5 +1,6 @@
 #if flash
 package mphx.client.impl ;
+import haxe.Timer;
 import flash.errors.EOFError;
 import flash.events.Event;
 import flash.events.IOErrorEvent;
@@ -52,13 +53,20 @@ class TcpFlashClient implements IClient
 
     public function connect():Void
     {
-        client = new Socket(host, port);
+        client = new Socket();
         //add specific handler for connection
         client.addEventListener(Event.CONNECT, onFlashConnectEvent);
         client.addEventListener(IOErrorEvent.IO_ERROR, onFlashIoErrorEventConnect);
         client.addEventListener(SecurityErrorEvent.SECURITY_ERROR, onFlashSecurityErrorEventConnect);
+		client.connect(host, port);
     }
 
+	//temporisation to wait the policyFiles from the server
+	private function waitForPolicyFiles(e: Event)
+	{
+		Timer.delay(onFlashConnectEvent.bind(e), 100);
+	}
+	
     private function onFlashConnectEvent(event : Event) : Void
     {
         trace("Connection established on : " + host +":" + port);

--- a/mphx/connection/impl/FlashConnection.hx
+++ b/mphx/connection/impl/FlashConnection.hx
@@ -119,13 +119,15 @@ class FlashConnection implements IConnection
 	public function recieve(line:String)
 	{
 		//flash specific, if we receive this, we need to return the policy files
-		if (line == "<policy-file-request/>")
+		//trace("my line = " + line);
+		
+		if (line.indexOf("<policy-file-request/>")!=-1)
 		{
-			trace("receive policyfile request");
 			cnx.socket.output.writeString(PolicyFilesProvider.generateXmlPolicyFile(domainAccept,Std.string(portAccept)).toString());
 			cnx.socket.output.flush();
 			return;
 		}
+		
 		var msg = serializer.deserialize(line);
 		events.callEvent(msg.t,msg.data,this);
 	}

--- a/mphx/utils/flash/PolicyFilesServer.hx
+++ b/mphx/utils/flash/PolicyFilesServer.hx
@@ -60,14 +60,36 @@ class PolicyFilesServer
 		if (cnx!=null)
 		{
 			cnx.waitForRead();
+			var read = "";
+			var error = "";
+			
+			while (true)
+			{
+				
+				try
+				{
+					read += cnx.input.readString(1);
+				}
+				catch (e : Dynamic)
+				{
+					error += e;
+					break;
+				}
+				
+			}
+			
+			//trace("PolicyfilesServer read : " + read);
+			//trace("PolicyfilesServer error : " + error);
 
 			//sending by default by adobe on Flash.net.socket.connect();
-			if (cnx.input.readString(22) == "<policy-file-request/>")
+			if (read.indexOf("<policy-file-request/>") !=-1)
 			{
 				var result = PolicyFilesProvider.generateXmlPolicyFile(domainAllowed, toPort).toString();
 				cnx.output.writeString(result);
 				cnx.output.flush();
 			}
+			
+			Sys.sleep(0.05);//wait before close for flush
 			cnx.close();
 		}
 	}


### PR DESCRIPTION
# some fix for this issue  : https://github.com/5Mixer/mphx/issues/19
- Correct flash client connection (add listener before connect (follow
  the tips of adobe air Docs)
- add a small timer after the client connection to wait the
  crossdomain.xml data (on port 843) to avoid the "insta-client-disconnect"
  because of wrong crossdomain data 
- [policyfiles server] better socket reading and add 5ms sleep before
  close the socket (to avoid some problems by calling cnx.close() just
  after a flush)
